### PR TITLE
Let dlx.la.Vector manage the scope of the petsc4py wrapper

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -68,6 +68,8 @@ jobs:
       - name: ruff Python interface checks
         run: |
           cd python/
+          ruff check .
+          ruff format --check .
       - name: mypy checks
         run: |
           cd python/

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -68,8 +68,6 @@ jobs:
       - name: ruff Python interface checks
         run: |
           cd python/
-          ruff check .
-          ruff format --check .
       - name: mypy checks
         run: |
           cd python/

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -339,7 +339,6 @@ class Function(ufl.Coefficient):
             V.element.dtype, np.dtype(dtype).type(0).real.dtype
         ), "Incompatible FunctionSpace dtype and requested dtype."
 
-
         # Create cpp Function
         def functiontype(dtype):
             if np.issubdtype(dtype, np.float32):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -370,6 +370,9 @@ class Function(ufl.Coefficient):
         # Store DOLFINx FunctionSpace object
         self._V = V
 
+        # Store casting to la.Vector
+        self._x = la.Vector(self._cpp_object.x) 
+
     @property
     def function_space(self) -> FunctionSpace:
         """The FunctionSpace that the Function is defined on"""
@@ -478,7 +481,7 @@ class Function(ufl.Coefficient):
     @property
     def x(self) -> la.Vector:
         """Vector holding the degrees-of-freedom."""
-        return la.Vector(self._cpp_object.x)  # type: ignore
+        return self._x  # type: ignore
 
     @property
     def vector(self):

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -370,7 +370,7 @@ class Function(ufl.Coefficient):
         self._V = V
 
         # Store casting to la.Vector
-        self._x = la.Vector(self._cpp_object.x) 
+        self._x = la.Vector(self._cpp_object.x)
 
     @property
     def function_space(self) -> FunctionSpace:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -339,9 +339,6 @@ class Function(ufl.Coefficient):
             V.element.dtype, np.dtype(dtype).type(0).real.dtype
         ), "Incompatible FunctionSpace dtype and requested dtype."
 
-        # PETSc Vec wrapper around the C++ function data (constructed
-        # when first requested)
-        self._petsc_x = None
 
         # Create cpp Function
         def functiontype(dtype):
@@ -372,10 +369,6 @@ class Function(ufl.Coefficient):
 
         # Store DOLFINx FunctionSpace object
         self._V = V
-
-    def __del__(self):
-        if self._petsc_x is not None:
-            self._petsc_x.destroy()
 
     @property
     def function_space(self) -> FunctionSpace:
@@ -489,21 +482,7 @@ class Function(ufl.Coefficient):
 
     @property
     def vector(self):
-        """PETSc vector holding the degrees-of-freedom.
-
-        Upon first call, this function creates a PETSc ``Vec`` object
-        that wraps the degree-of-freedom data. The ``Vec`` object is
-        cached and the cached ``Vec`` is returned upon subsequent calls.
-
-        Note:
-            Prefer :func`x` where possible.
-
-        """
-        if self._petsc_x is None:
-            from dolfinx.la import create_petsc_vector_wrap
-
-            self._petsc_x = create_petsc_vector_wrap(self.x)
-        return self._petsc_x
+        return self.x().vector
 
     @property
     def dtype(self) -> np.dtype:

--- a/python/dolfinx/fem/function.py
+++ b/python/dolfinx/fem/function.py
@@ -482,7 +482,17 @@ class Function(ufl.Coefficient):
 
     @property
     def vector(self):
-        return self.x().vector
+        """PETSc vector holding the degrees-of-freedom.
+
+        Upon first call, this function creates a PETSc ``Vec`` object
+        that wraps the degree-of-freedom data. The ``Vec`` object is
+        cached and the cached ``Vec`` is returned upon subsequent calls.
+
+        Note:
+            Prefer :func`x` where possible.
+
+        """
+        return self.x.vector
 
     @property
     def dtype(self) -> np.dtype:

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -229,6 +229,11 @@ class Vector:
             User code should call :func:`vector` to create a vector object.
         """
         self._cpp_object = x
+        self._petsc_x = None
+
+    def __del__(self):
+        if self._petsc_x is not None:
+            self._petsc_x.destroy()
 
     @property
     def index_map(self) -> IndexMap:
@@ -244,6 +249,20 @@ class Vector:
     def array(self) -> np.ndarray:
         """Local representation of the vector."""
         return self._cpp_object.array
+
+    @property
+    def vector(self):
+        """PETSc vector holding the entries of the vector.
+
+        Upon first call, this function creates a PETSc ``Vec`` object
+        that wraps the degree-of-freedom data. The ``Vec`` object is
+        cached and the cached ``Vec`` is returned upon subsequent calls.
+        """
+        if self._petsc_x is None:
+            from dolfinx.la import create_petsc_vector_wrap
+
+            self._petsc_x = create_petsc_vector_wrap(self.x)
+        return self._petsc_x
 
     def scatter_forward(self) -> None:
         """Update ghost entries."""

--- a/python/dolfinx/la.py
+++ b/python/dolfinx/la.py
@@ -259,9 +259,7 @@ class Vector:
         cached and the cached ``Vec`` is returned upon subsequent calls.
         """
         if self._petsc_x is None:
-            from dolfinx.la import create_petsc_vector_wrap
-
-            self._petsc_x = create_petsc_vector_wrap(self.x)
+            self._petsc_x = create_petsc_vector_wrap(self)
         return self._petsc_x
 
     def scatter_forward(self) -> None:


### PR DESCRIPTION
This PR allows a a `dlx.la.Vector` (rather than a `dlx.fem.Function`) to manage the memory and the scope of the `petsc4py.PETSc.vec` object that wraps the underlying data.

The implementation of the property `dlx.fem.Function.vector` was also modified to delegate the creation of the wrapper to the underlying `dlx.la.Vector`.

All changes are backward compatible.